### PR TITLE
Build on all platforms, use Julia 1.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 1.0
 notifications:
   email: false
 git:
@@ -19,8 +19,8 @@ sudo: required
 
 # Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryProvider.jl")'
-  - julia -e 'Pkg.clone("https://github.com/JuliaPackaging/BinaryBuilder.jl"); Pkg.build()'
+  - julia -e 'using Pkg; Pkg.add("BinaryProvider")'
+  - julia -e 'using Pkg; Pkg.develop("BinaryBuilder"); Pkg.build("BinaryBuilder")'
 
 script:
   - julia build_tarballs.jl

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -18,16 +18,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    BinaryProvider.Linux(:i686, :glibc),
-    BinaryProvider.Linux(:x86_64, :glibc),
-    BinaryProvider.Linux(:aarch64, :glibc),
-    BinaryProvider.Linux(:armv7l, :glibc),
-    BinaryProvider.Linux(:powerpc64le, :glibc),
-    BinaryProvider.MacOS(),
-    BinaryProvider.Windows(:i686),
-    BinaryProvider.Windows(:x86_64)
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -1,10 +1,12 @@
 using BinaryBuilder
 
+name = "libffi"
+version = v"3.2.1"
+
 # Collection of sources required to build libffi
 sources = [
     "https://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz" =>
     "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37",
-
 ]
 
 # Bash recipe for building across all platforms
@@ -26,10 +28,7 @@ products(prefix) = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = [
-    
-]
+dependencies = []
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, "libffi", sources, script, platforms, products, dependencies)
-
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)


### PR DESCRIPTION
This replaces the explicit list of platforms with `supported_platforms()` and adjusts the Travis setup to use Julia 1.0 and Pkg3.